### PR TITLE
docs: Add the explanation for system design decisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,13 @@ Essays represent a person's critical thinking. It provides a glimpse into a pers
 
 ## Methodolgy & Strategic Design Decisions
 1. We chose to load all the models and tokenizers at the start of the server, so we can serve every request within a definitive range of latency.
+    - The trade-off is between postponing the download of all the supported tokenizer and models until they are asked for and serving results by all the models with a constant and definitive latency even for the first time.
+    - The former approach does not download all the models and tokenizers before initializing the backend Fastapi server. This would only download the tokenizer and the model that is asked for. For e.g., if the LSTM model is not asked for the first 10 days, then it would save local storage space of storing the LSTM model for those 10 days. 
+    - But the limitation of this approach is that, for the first request that asks for the new model, it would have to bear the time delay of downlaoding and loading the model. It would also need complex logic of maintaining multiple threads from downloading the new model when it is demanded concurrently.
+    - The later approach takes a little bit longer to start the server as it downloads all the tokenizers and models before initializing the backend server. This would also help in serving every request, even the very first request for each model, in a predictive and definitive time without any anomalies.
+    - It would also provide the benefit of robust availability and readiness of all the models befores serving the users.
 
-## Impending work
+2. Storing the file paths as environment variables.
+
+
+## Impending work 


### PR DESCRIPTION
Explained the design decision of downloading and saving all the tokenizers and models locally, prior to initializing the backend server and serving the users.